### PR TITLE
Ternary isn't needed

### DIFF
--- a/React_files/src/containers/App.js
+++ b/React_files/src/containers/App.js
@@ -50,9 +50,9 @@ const App = () =>  {
 					handleClick={handleClick}
 				/>
 				{/* CONDITIONALLY RENDER RESULTS */}
-				{isRender ? (
+				{isRender && (
 					<ResultBox type={waste.type} weight={waste.weight} recycling={recycling} />
-				) : null}
+				)}
 			</div>
 		);
 	


### PR DESCRIPTION
The ternary operator isn't needed when the else returns null, AND operator is the better syntax.